### PR TITLE
bugfix: all fixes to ttl value were lost

### DIFF
--- a/src/Dyndns/Hosts.php
+++ b/src/Dyndns/Hosts.php
@@ -170,7 +170,6 @@ class Hosts
         }
         fwrite($fh, "server $server\n");
         fwrite($fh, "zone $zone\n");
-        $ttl = $this->getConfig('bind.ttl');
         foreach ($this->updates as $host => $ip) {
             fwrite($fh, "update delete $host A\n");
             fwrite($fh, "update add $host $ttl A $ip\n");


### PR DESCRIPTION
In the first lines of the function `updateBind()` you read `ttl` value from the configuration, then some sanity checks are performed:
- the value must be int
- the value must be at least 300

The problem is that when it get written to create the actual `nsupdate` command, the value is taken again from the original configuration loosing all the performed sanity checks.
